### PR TITLE
ci(github): cache go build state in build_publish

### DIFF
--- a/.github/workflows/_build_publish.yaml
+++ b/.github/workflows/_build_publish.yaml
@@ -55,6 +55,15 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+      - name: Cache Go build
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           # TODO: drop once https://github.com/jdx/mise/discussions/9889 is fixed (mise v2026.5.8 broke cosign public-key bundle verification).
@@ -110,6 +119,15 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+      - name: Cache Go build
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-build-${{ runner.os }}-
       - name: Install dependencies for cross builds
         if: ${{ fromJSON(inputs.FULL_MATRIX) }}
         run: |


### PR DESCRIPTION
## Motivation

Speed up `build_publish` in CI.
On the fork validation runs, `Cache Go build` + `make build` took **3m32s** and **3m34s**, versus **9m31s** for `make build` alone on https://github.com/kumahq/kuma/actions/runs/26252769629, so even including the restore overhead the sample was still about **6m faster**.
I also want to confirm whether we previously used this Go build/module cache in `build_publish` and intentionally removed it for some reason.

## Implementation information

- restore the Go build and module cache in `build-binaries`
- restore the Go build and module cache in `build-images`
- validate the timing on the fork before opening anything against `kumahq/kuma`

## Supporting documentation

- fork validation PR: https://github.com/slonka/kuma/pull/608
- upstream comparison run: https://github.com/kumahq/kuma/actions/runs/26252769629
